### PR TITLE
build: Use `venice_core` GitHub package in CI

### DIFF
--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -10,6 +10,10 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
+      - name: Remove local venice_core dependency
+        run: flutter pub remove venice_core
+      - name: Install venice_core from GitHub
+        run: flutter pub add venice_core --git-url=https://github.com/Venice-D2D/venice_core
       - run: flutter pub get
       - name: Lint analysis
         run: flutter analyze
@@ -22,6 +26,10 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
+      - name: Remove local venice_core dependency
+          run: flutter pub remove venice_core
+      - name: Install venice_core from GitHub
+        run: flutter pub add venice_core --git-url=https://github.com/Venice-D2D/venice_core
       - run: flutter pub get
       - name: Run tests
         run: flutter test

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           channel: 'stable'
       - name: Remove local venice_core dependency
-          run: flutter pub remove venice_core
+        run: flutter pub remove venice_core
       - name: Install venice_core from GitHub
         run: flutter pub add venice_core --git-url=https://github.com/Venice-D2D/venice_core
       - run: flutter pub get


### PR DESCRIPTION
In `master`, local `venice_core` package is used (`path: ../venice_core`), which prevent current package from being built and tested by CI.