### PR TITLE
build: Use `venice_core` GitHub dependency in entire project

### DIFF
--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -10,10 +10,6 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
-      - name: Remove local venice_core dependency
-        run: flutter pub remove venice_core
-      - name: Install venice_core from GitHub
-        run: flutter pub add venice_core --git-url=https://github.com/Venice-D2D/venice_core
       - run: flutter pub get
       - name: Lint analysis
         run: flutter analyze
@@ -26,10 +22,6 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
-      - name: Remove local venice_core dependency
-        run: flutter pub remove venice_core
-      - name: Install venice_core from GitHub
-        run: flutter pub add venice_core --git-url=https://github.com/Venice-D2D/venice_core
       - run: flutter pub get
       - name: Run tests
         run: flutter test

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   flutter:
     sdk: flutter
   venice_core:
-    path: ../venice_core
+    git: https://github.com/Venice-D2D/venice_core.git
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
It's easier using Github dependency directly, so that projects depending on `delta_scheduler` don't have to clone `venice_core` themselves.